### PR TITLE
fix YOLOV8 example README bug

### DIFF
--- a/example/yolov8/README.md
+++ b/example/yolov8/README.md
@@ -20,7 +20,7 @@ Please refer to the [Ryzen AI SW platform installation guide](https://ryzenai.do
 cd tutorial\yolov8_e2e\yolov8
 ### Jpeg sample
 ```
-.\run_jpeg.bat .\DetectionModel_int.onnx .\sample_yolov5.jpg
+.\run_jpeg.bat .\DetectionModel_int.onnx .\sample_yolov8.jpg
 ```
 Output:      
 result: 0       person  490.38498       85.79535        640.00488       475.18262       0.932453     

--- a/example/yolov8/README.md
+++ b/example/yolov8/README.md
@@ -14,7 +14,7 @@ Please refer to the [Ryzen AI SW platform installation guide](https://ryzenai.do
     ├── yolov8
            └── yolov8_e2e
     └── ...
-
+```
 ## Run 
 cd tutorial\yolov8_e2e\yolov8
 ### Jpeg sample

--- a/example/yolov8/README.md
+++ b/example/yolov8/README.md
@@ -4,6 +4,7 @@ Please refer to the [Ryzen AI SW platform installation guide](https://ryzenai.do
 
 ## How to build:
 1. move `yolov8`(path: example/yolov8) folder into the 'yolov8_e2e' folder (path: tutorial/yolov8_e2e/..)
+```
 └── yolov8_e2e
     ├── bin
     ├── code 
@@ -13,6 +14,7 @@ Please refer to the [Ryzen AI SW platform installation guide](https://ryzenai.do
     ├── yolov8
            └── yolov8_e2e
     └── ...
+
 ## Run 
 cd tutorial\yolov8_e2e\yolov8
 ### Jpeg sample

--- a/example/yolov8/README.md
+++ b/example/yolov8/README.md
@@ -12,7 +12,8 @@ Please refer to the [Ryzen AI SW platform installation guide](https://ryzenai.do
     ├── vitis_ai_ep_cxx_samples
     ├── vitis_ai_ep_py_samples
     ├── yolov8
-           └── yolov8_e2e
+           └── video
+           └── yolov8
     └── ...
 ```
 ## Run 

--- a/example/yolov8/README.md
+++ b/example/yolov8/README.md
@@ -3,21 +3,18 @@ This package provides 3 yolov8 sample that running on RyzenAI and OnnxRuntime(Vi
 Please refer to the [Ryzen AI SW platform installation guide](https://ryzenai.docs.amd.com/en/latest/inst.html#) to install all the dependent packages. 
 
 ## How to build:
-1. move `Yolov8` folder to `VOE` folder(same level as **vitis_ai_ep_cxx_sample**)
-
-2. ./build.bat
-
-Output:
-```
-    ......
-    -- Installing: C:/Users/ibane/Desktop/voe-win_amd64-with_xcompiler_on-c07e419-latest/bin/camera_yolov8.exe
-    -- Installing: C:/Users/ibane/Desktop/voe-win_amd64-with_xcompiler_on-c07e419-latest/bin/camera_yolov8_nx1x4.exe
-    -- Installing: C:/Users/ibane/Desktop/voe-win_amd64-with_xcompiler_on-c07e419-latest/bin/test_jpeg_yolov8.exe
-```
-
-
+1. move `yolov8`(path: example/yolov8) folder into the 'yolov8_e2e' folder (path: tutorial/yolov8_e2e/..)
+└── yolov8_e2e
+    ├── bin
+    ├── code 
+    ├── images
+    ├── vitis_ai_ep_cxx_samples
+    ├── vitis_ai_ep_py_samples
+    ├── yolov8
+           └── yolov8_e2e
+    └── ...
 ## Run 
-
+cd tutorial\yolov8_e2e\yolov8
 ### Jpeg sample
 ```
 .\run_jpeg.bat .\DetectionModel_int.onnx .\sample_yolov5.jpg


### PR DESCRIPTION
old version  build error
Solution:
Just move the folder,  because the build.bat's results: three xxx.exe files has been already in the /tutorial/yolov8_e2e/bin folder.