### PR TITLE
Printing timing information for text generation in ONNX flow 

### DIFF
--- a/example/opt-1.3b/opt-onnx/README.MD
+++ b/example/opt-1.3b/opt-onnx/README.MD
@@ -185,7 +185,7 @@ Each run generates a log directory `log_<model_name>`. The log files in this dir
 
 Gilgamesh is a character from the epic poem Gilgamesh. He is the son of the god
 ```
-Here, the time taken by the tokenizer, time taken for generation of 30 tokens, number of tokens in the prompt, and time taken for decoding the genrations are saved.
+This log reports total time to generate the all the tokens (which is 30 in the above example) for the given input prompt, along with input prompt token length. The timing information for tokenizing and decoding are also saved. 
 
 
 ### Perplexity on wikitext2-raw dataset

--- a/example/opt-1.3b/opt-onnx/README.MD
+++ b/example/opt-1.3b/opt-onnx/README.MD
@@ -149,7 +149,6 @@ options:
   --dataset {non-raw,raw}
                         wikitext2-raw-v1, wikitext2-v1
 ```
-Each run generates a log directory `log_<model_name>` and all logs are within this directory. 
 
 ### Decode prompts
 Use the following commands to execute the quantized ONNX models on the CPU and IPU. 
@@ -166,13 +165,29 @@ python run.py --model_name opt-1.3b --target cpu --disable_cache --local_path ./
 python run.py --model_name opt-1.3b --target aie --disable_cache --local_path ./opt-1.3b_ortquantized 
 ```
 
-One example of an answer is shown below.
+One example of an answer is shown below. The time taken to generate a single token is also printed out.
 ```
 Prompt: Who is Gilgamesh?
 Response: 
 
 Gilgamesh is a character from the epic poem Gilgamesh. He is the son of the god
+Time taken to generate one token: 218.01996231079102  ms 
 ```
+
+Each run generates a log directory `log_<model_name>`. The log files in this directory contain more timing information for the decode and generation process. Here is a snippet from the logfile: 
+
+```
+18:11:16,618 root CRITICAL ****************************************
+18:11:16,618 root CRITICAL [PROFILE][WARMUP] tokenizer: 0.0
+18:11:21,633 root CRITICAL [PROFILE][AIE] generate: 5.014459133148193 for 30 tokens; prompt-tokens: 7
+18:11:21,633 root CRITICAL [PROFILE][WARMUP] tokenizer decode: 0.0
+18:11:21,633 root CRITICAL response: Who is Gilgamesh?
+
+Gilgamesh is a character from the epic poem Gilgamesh. He is the son of the god
+```
+Here, the time taken by the tokenizer, time taken for generation of 30 tokens, number of tokens in the prompt, and time taken for decoding the genrations are saved.
+
+
 ### Perplexity on wikitext2-raw dataset
 [Perplexity](https://huggingface.co/docs/transformers/perplexity) is a metric commonly used to evaluate language models. It represents the model's ability to generate uniformly among the set of specified tokens in the corpus. Specifically, it quantifies how surprised or uncertain the model is when trying to predict the next word in a sequence based on the context of the previous words. A lower perplexity indicates that the model is better at predicting the next word, while a higher perplexity suggests that the model struggles with the prediction.
 

--- a/example/opt-1.3b/opt-onnx/README.MD
+++ b/example/opt-1.3b/opt-onnx/README.MD
@@ -171,7 +171,7 @@ Prompt: Who is Gilgamesh?
 Response: 
 
 Gilgamesh is a character from the epic poem Gilgamesh. He is the son of the god
-Time taken to generate one token: 218.01996231079102  ms 
+Average time to generate each new token: 218.01996231079102  ms 
 ```
 
 Each run generates a log directory `log_<model_name>`. The log files in this directory contain more timing information for the decode and generation process. Here is a snippet from the logfile: 

--- a/example/opt-1.3b/opt-onnx/model_utils.py
+++ b/example/opt-1.3b/opt-onnx/model_utils.py
@@ -265,6 +265,7 @@ def decode_prompt(model, tokenizer, prompt, input_ids=None, max_new_tokens=30):
     logging.critical(f"[PROFILE][WARMUP] tokenizer decode: {end-start}")
     
     print(f"response: {response}")
+    print("Time taken to generate one token:",time_per_token," ms")
     logging.critical(f"response: {response}")
             
 

--- a/example/opt-1.3b/opt-onnx/model_utils.py
+++ b/example/opt-1.3b/opt-onnx/model_utils.py
@@ -265,7 +265,7 @@ def decode_prompt(model, tokenizer, prompt, input_ids=None, max_new_tokens=30):
     logging.critical(f"[PROFILE][WARMUP] tokenizer decode: {end-start}")
     
     print(f"response: {response}")
-    print("Time taken to generate one token:",time_per_token," ms")
+    print("Average time to generate each new token:",time_per_token," ms")
     logging.critical(f"response: {response}")
             
 


### PR DESCRIPTION
Updating model_utils.py to print the average generation time per token. 
Updating README with timing information.