### PR TITLE
Add LLM guides to the examples folder

### DIFF
--- a/example/llm/README.md
+++ b/example/llm/README.md
@@ -1,0 +1,86 @@
+# Ryzen AI LLM Examples
+
+The following table contains a comprehensive list of all LLMs that have been validated on Ryzen AI hybrid execution mode, along with CPU implementations of those same checkpoints. 
+
+The hybrid examples are built on top of OnnxRuntime GenAI (OGA), while the CPU baseline is built on top of Hugging Face (HF) ``transformers``. Validation is defined as running all commands in the example page successfully.
+
+<table class="tg"><thead>
+  <tr>
+    <th class="tg-invis"></th>
+    <th class="tg-top" colspan="2">CPU (Hugging Face bfloat16)</th>
+    <th class="tg-top" colspan="2">Ryzen AI Hybrid (OGA int4)</th>
+  </tr></thead>
+<tbody>
+  <tr>
+    <td class="tg-heading">Model</td>
+    <td class="tg-heading">Example</td>
+    <td class="tg-heading">Validation</td>
+    <td class="tg-heading">Example</td>
+    <td class="tg-heading">Validation</td>
+  </tr>
+  <tr>
+        <td class="tg-cell-nowrap"><a href="https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct">Llama-3.2-1B-Instruct</a></td><!--Model-->
+        <td class="tg-cell"><a href="cpu/Llama_3_2_1B_Instruct.md">Link</a></td><!--cpu Example-->
+    <td class="tg-cell">🟢</td><!--cpu validation-->
+    <td class="tg-cell"><a href="hybrid/Llama_3_2_1B_Instruct.md">Link</a></td><!--hybrid Example-->
+    <td class="tg-cell">🟢</td><!--hybrid validation-->
+  </tr><tr>
+        <td class="tg-cell-nowrap"><a href="https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct">Llama-3.2-3B-Instruct</a></td><!--Model-->
+        <td class="tg-cell"><a href="cpu/Llama_3_2_3B_Instruct.md">Link</a></td><!--cpu Example-->
+    <td class="tg-cell">🟢</td><!--cpu validation-->
+    <td class="tg-cell"><a href="hybrid/Llama_3_2_3B_Instruct.md">Link</a></td><!--hybrid Example-->
+    <td class="tg-cell">🟢</td><!--hybrid validation-->
+  </tr><tr>
+        <td class="tg-cell-nowrap"><a href="https://huggingface.co/microsoft/Phi-3-mini-4k-instruct">Phi-3-mini-4k-instruct</a></td><!--Model-->
+        <td class="tg-cell"><a href="cpu/Phi_3_mini_4k_instruct.md">Link</a></td><!--cpu Example-->
+    <td class="tg-cell">🟢</td><!--cpu validation-->
+    <td class="tg-cell"><a href="hybrid/Phi_3_mini_4k_instruct.md">Link</a></td><!--hybrid Example-->
+    <td class="tg-cell">🟢</td><!--hybrid validation-->
+  </tr><tr>
+        <td class="tg-cell-nowrap"><a href="https://huggingface.co/microsoft/Phi-3.5-mini-instruct">Phi-3.5-mini-instruct</a></td><!--Model-->
+        <td class="tg-cell"><a href="cpu/Phi_3_5_mini_instruct.md">Link</a></td><!--cpu Example-->
+    <td class="tg-cell">🟢</td><!--cpu validation-->
+    <td class="tg-cell"><a href="hybrid/Phi_3_5_mini_instruct.md">Link</a></td><!--hybrid Example-->
+    <td class="tg-cell">🟢</td><!--hybrid validation-->
+  </tr><tr>
+        <td class="tg-cell-nowrap"><a href="https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3">Mistral-7B-Instruct-v0.3</a></td><!--Model-->
+        <td class="tg-cell"><a href="cpu/Mistral_7B_Instruct_v0_3.md">Link</a></td><!--cpu Example-->
+    <td class="tg-cell">🟢</td><!--cpu validation-->
+    <td class="tg-cell"><a href="hybrid/Mistral_7B_Instruct_v0_3.md">Link</a></td><!--hybrid Example-->
+    <td class="tg-cell">🟢</td><!--hybrid validation-->
+  </tr><tr>
+        <td class="tg-cell-nowrap"><a href="https://huggingface.co/Qwen/Qwen1.5-7B-Chat">Qwen1.5-7B-Chat</a></td><!--Model-->
+        <td class="tg-cell"><a href="cpu/Qwen1_5_7B_Chat.md">Link</a></td><!--cpu Example-->
+    <td class="tg-cell">🟢</td><!--cpu validation-->
+    <td class="tg-cell"><a href="hybrid/Qwen1_5_7B_Chat.md">Link</a></td><!--hybrid Example-->
+    <td class="tg-cell">🟢</td><!--hybrid validation-->
+  </tr><tr>
+        <td class="tg-cell-nowrap"><a href="https://huggingface.co/meta-llama/Llama-2-7b-hf">Llama-2-7b-hf</a></td><!--Model-->
+        <td class="tg-cell"><a href="cpu/Llama_2_7b_hf.md">Link</a></td><!--cpu Example-->
+    <td class="tg-cell">🟢</td><!--cpu validation-->
+    <td class="tg-cell"><a href="hybrid/Llama_2_7b_hf.md">Link</a></td><!--hybrid Example-->
+    <td class="tg-cell">🟢</td><!--hybrid validation-->
+  </tr><tr>
+        <td class="tg-cell-nowrap"><a href="https://huggingface.co/meta-llama/Llama-2-7b-chat-hf">Llama-2-7b-chat-hf</a></td><!--Model-->
+        <td class="tg-cell"><a href="cpu/Llama_2_7b_chat_hf.md">Link</a></td><!--cpu Example-->
+    <td class="tg-cell">🟢</td><!--cpu validation-->
+    <td class="tg-cell"><a href="hybrid/Llama_2_7b_chat_hf.md">Link</a></td><!--hybrid Example-->
+    <td class="tg-cell">🟢</td><!--hybrid validation-->
+  </tr><tr>
+        <td class="tg-cell-nowrap"><a href="https://huggingface.co/meta-llama/Meta-Llama-3-8B">Meta-Llama-3-8B</a></td><!--Model-->
+        <td class="tg-cell"><a href="cpu/Meta_Llama_3_8B.md">Link</a></td><!--cpu Example-->
+    <td class="tg-cell">🟢</td><!--cpu validation-->
+    <td class="tg-cell"><a href="hybrid/Meta_Llama_3_8B.md">Link</a></td><!--hybrid Example-->
+    <td class="tg-cell">🟢</td><!--hybrid validation-->
+  </tr><tr>
+        <td class="tg-cell-nowrap"><a href="https://huggingface.co/meta-llama/Llama-3.1-8B">Llama-3.1-8B</a></td><!--Model-->
+        <td class="tg-cell"><a href="cpu/Llama_3_1_8B.md">Link</a></td><!--cpu Example-->
+    <td class="tg-cell">🟢</td><!--cpu validation-->
+    <td class="tg-cell"><a href="hybrid/Llama_3_1_8B.md">Link</a></td><!--hybrid Example-->
+    <td class="tg-cell">🟢</td><!--hybrid validation-->
+  </tr>
+</tbody></table>
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/cpu/Llama_2_7b_chat_hf.md
+++ b/example/llm/cpu/Llama_2_7b_chat_hf.md
@@ -1,0 +1,147 @@
+# Hugging Face CPU: meta-llama/Llama-2-7b-chat-hf (bfloat16)
+
+This guide contains all of the instructions necessary to get started with the model `meta-llama/Llama-2-7b-chat-hf` on Hugging Face CPU in the bfloat16 data type.
+
+The CPU implementation in this guide is designed to run on most PCs. However, for optimal performance on Ryzen AI 300-series PCs, try the [hybrid execution mode](../hybrid/Llama_2_7b_chat_hf.md).
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework, as well as the support for Hugging Face `transformers` baselines leveraged in this guide.
+
+# Checkpoint
+
+The Hugging Face CPU implementation of `meta-llama/Llama-2-7b-chat-hf` uses the ONNX Runtime GenAI Model Builder tool, via `lemonade` to export an ONNX model for use in inference.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm]
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i meta-llama/Llama-2-7b-chat-hf huggingface-load --device cpu --dtype bfloat16 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i meta-llama/Llama-2-7b-chat-hf huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i meta-llama/Llama-2-7b-chat-hf huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "meta-llama/Llama-2-7b-chat-hf", recipe="hf-cpu"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from transformers import TextIteratorStreamer
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained("meta-llama/Llama-2-7b-chat-hf", recipe="hf-cpu")
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = TextIteratorStreamer(
+    tokenizer,
+    skip_prompt=True,
+)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/cpu/Llama_2_7b_chat_hf.md
+++ b/example/llm/cpu/Llama_2_7b_chat_hf.md
@@ -57,7 +57,7 @@ lemonade -i meta-llama/Llama-2-7b-chat-hf huggingface-load --device cpu --dtype 
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i meta-llama/Llama-2-7b-chat-hf huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i meta-llama/Llama-2-7b-chat-hf huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -65,7 +65,7 @@ lemonade -i meta-llama/Llama-2-7b-chat-hf huggingface-load --device cpu --dtype 
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i meta-llama/Llama-2-7b-chat-hf huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i meta-llama/Llama-2-7b-chat-hf huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/cpu/Llama_2_7b_chat_hf.md
+++ b/example/llm/cpu/Llama_2_7b_chat_hf.md
@@ -120,9 +120,7 @@ for new_text in streamer:
 thread.join()
 ```
 
-## Application Example
 
-See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
 
 # Server Interface (REST API)
 

--- a/example/llm/cpu/Llama_2_7b_hf.md
+++ b/example/llm/cpu/Llama_2_7b_hf.md
@@ -1,0 +1,147 @@
+# Hugging Face CPU: meta-llama/Llama-2-7b-hf (bfloat16)
+
+This guide contains all of the instructions necessary to get started with the model `meta-llama/Llama-2-7b-hf` on Hugging Face CPU in the bfloat16 data type.
+
+The CPU implementation in this guide is designed to run on most PCs. However, for optimal performance on Ryzen AI 300-series PCs, try the [hybrid execution mode](../hybrid/Llama_2_7b_hf.md).
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework, as well as the support for Hugging Face `transformers` baselines leveraged in this guide.
+
+# Checkpoint
+
+The Hugging Face CPU implementation of `meta-llama/Llama-2-7b-hf` uses the ONNX Runtime GenAI Model Builder tool, via `lemonade` to export an ONNX model for use in inference.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm]
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i meta-llama/Llama-2-7b-hf huggingface-load --device cpu --dtype bfloat16 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i meta-llama/Llama-2-7b-hf huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i meta-llama/Llama-2-7b-hf huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "meta-llama/Llama-2-7b-hf", recipe="hf-cpu"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from transformers import TextIteratorStreamer
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained("meta-llama/Llama-2-7b-hf", recipe="hf-cpu")
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = TextIteratorStreamer(
+    tokenizer,
+    skip_prompt=True,
+)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/cpu/Llama_2_7b_hf.md
+++ b/example/llm/cpu/Llama_2_7b_hf.md
@@ -57,7 +57,7 @@ lemonade -i meta-llama/Llama-2-7b-hf huggingface-load --device cpu --dtype bfloa
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i meta-llama/Llama-2-7b-hf huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i meta-llama/Llama-2-7b-hf huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -65,7 +65,7 @@ lemonade -i meta-llama/Llama-2-7b-hf huggingface-load --device cpu --dtype bfloa
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i meta-llama/Llama-2-7b-hf huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i meta-llama/Llama-2-7b-hf huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/cpu/Llama_2_7b_hf.md
+++ b/example/llm/cpu/Llama_2_7b_hf.md
@@ -120,9 +120,7 @@ for new_text in streamer:
 thread.join()
 ```
 
-## Application Example
 
-See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
 
 # Server Interface (REST API)
 

--- a/example/llm/cpu/Llama_3_1_8B.md
+++ b/example/llm/cpu/Llama_3_1_8B.md
@@ -1,0 +1,147 @@
+# Hugging Face CPU: meta-llama/Llama-3.1-8B (bfloat16)
+
+This guide contains all of the instructions necessary to get started with the model `meta-llama/Llama-3.1-8B` on Hugging Face CPU in the bfloat16 data type.
+
+The CPU implementation in this guide is designed to run on most PCs. However, for optimal performance on Ryzen AI 300-series PCs, try the [hybrid execution mode](../hybrid/Llama_3_1_8B.md).
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework, as well as the support for Hugging Face `transformers` baselines leveraged in this guide.
+
+# Checkpoint
+
+The Hugging Face CPU implementation of `meta-llama/Llama-3.1-8B` uses the ONNX Runtime GenAI Model Builder tool, via `lemonade` to export an ONNX model for use in inference.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm]
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i meta-llama/Llama-3.1-8B huggingface-load --device cpu --dtype bfloat16 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i meta-llama/Llama-3.1-8B huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i meta-llama/Llama-3.1-8B huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "meta-llama/Llama-3.1-8B", recipe="hf-cpu"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from transformers import TextIteratorStreamer
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained("meta-llama/Llama-3.1-8B", recipe="hf-cpu")
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = TextIteratorStreamer(
+    tokenizer,
+    skip_prompt=True,
+)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/cpu/Llama_3_1_8B.md
+++ b/example/llm/cpu/Llama_3_1_8B.md
@@ -57,7 +57,7 @@ lemonade -i meta-llama/Llama-3.1-8B huggingface-load --device cpu --dtype bfloat
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i meta-llama/Llama-3.1-8B huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i meta-llama/Llama-3.1-8B huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -65,7 +65,7 @@ lemonade -i meta-llama/Llama-3.1-8B huggingface-load --device cpu --dtype bfloat
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i meta-llama/Llama-3.1-8B huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i meta-llama/Llama-3.1-8B huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/cpu/Llama_3_1_8B.md
+++ b/example/llm/cpu/Llama_3_1_8B.md
@@ -120,9 +120,7 @@ for new_text in streamer:
 thread.join()
 ```
 
-## Application Example
 
-See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
 
 # Server Interface (REST API)
 

--- a/example/llm/cpu/Llama_3_2_1B_Instruct.md
+++ b/example/llm/cpu/Llama_3_2_1B_Instruct.md
@@ -57,7 +57,7 @@ lemonade -i meta-llama/Llama-3.2-1B-Instruct huggingface-load --device cpu --dty
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i meta-llama/Llama-3.2-1B-Instruct huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i meta-llama/Llama-3.2-1B-Instruct huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -65,7 +65,7 @@ lemonade -i meta-llama/Llama-3.2-1B-Instruct huggingface-load --device cpu --dty
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i meta-llama/Llama-3.2-1B-Instruct huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i meta-llama/Llama-3.2-1B-Instruct huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/cpu/Llama_3_2_1B_Instruct.md
+++ b/example/llm/cpu/Llama_3_2_1B_Instruct.md
@@ -1,0 +1,147 @@
+# Hugging Face CPU: meta-llama/Llama-3.2-1B-Instruct (bfloat16)
+
+This guide contains all of the instructions necessary to get started with the model `meta-llama/Llama-3.2-1B-Instruct` on Hugging Face CPU in the bfloat16 data type.
+
+The CPU implementation in this guide is designed to run on most PCs. However, for optimal performance on Ryzen AI 300-series PCs, try the [hybrid execution mode](../hybrid/Llama_3_2_1B_Instruct.md).
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework, as well as the support for Hugging Face `transformers` baselines leveraged in this guide.
+
+# Checkpoint
+
+The Hugging Face CPU implementation of `meta-llama/Llama-3.2-1B-Instruct` uses the ONNX Runtime GenAI Model Builder tool, via `lemonade` to export an ONNX model for use in inference.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm]
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i meta-llama/Llama-3.2-1B-Instruct huggingface-load --device cpu --dtype bfloat16 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i meta-llama/Llama-3.2-1B-Instruct huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i meta-llama/Llama-3.2-1B-Instruct huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "meta-llama/Llama-3.2-1B-Instruct", recipe="hf-cpu"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from transformers import TextIteratorStreamer
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained("meta-llama/Llama-3.2-1B-Instruct", recipe="hf-cpu")
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = TextIteratorStreamer(
+    tokenizer,
+    skip_prompt=True,
+)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/cpu/Llama_3_2_1B_Instruct.md
+++ b/example/llm/cpu/Llama_3_2_1B_Instruct.md
@@ -120,9 +120,7 @@ for new_text in streamer:
 thread.join()
 ```
 
-## Application Example
 
-See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
 
 # Server Interface (REST API)
 

--- a/example/llm/cpu/Llama_3_2_3B_Instruct.md
+++ b/example/llm/cpu/Llama_3_2_3B_Instruct.md
@@ -1,0 +1,147 @@
+# Hugging Face CPU: meta-llama/Llama-3.2-3B-Instruct (bfloat16)
+
+This guide contains all of the instructions necessary to get started with the model `meta-llama/Llama-3.2-3B-Instruct` on Hugging Face CPU in the bfloat16 data type.
+
+The CPU implementation in this guide is designed to run on most PCs. However, for optimal performance on Ryzen AI 300-series PCs, try the [hybrid execution mode](../hybrid/Llama_3_2_3B_Instruct.md).
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework, as well as the support for Hugging Face `transformers` baselines leveraged in this guide.
+
+# Checkpoint
+
+The Hugging Face CPU implementation of `meta-llama/Llama-3.2-3B-Instruct` uses the ONNX Runtime GenAI Model Builder tool, via `lemonade` to export an ONNX model for use in inference.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm]
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i meta-llama/Llama-3.2-3B-Instruct huggingface-load --device cpu --dtype bfloat16 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i meta-llama/Llama-3.2-3B-Instruct huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i meta-llama/Llama-3.2-3B-Instruct huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "meta-llama/Llama-3.2-3B-Instruct", recipe="hf-cpu"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from transformers import TextIteratorStreamer
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained("meta-llama/Llama-3.2-3B-Instruct", recipe="hf-cpu")
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = TextIteratorStreamer(
+    tokenizer,
+    skip_prompt=True,
+)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/cpu/Llama_3_2_3B_Instruct.md
+++ b/example/llm/cpu/Llama_3_2_3B_Instruct.md
@@ -57,7 +57,7 @@ lemonade -i meta-llama/Llama-3.2-3B-Instruct huggingface-load --device cpu --dty
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i meta-llama/Llama-3.2-3B-Instruct huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i meta-llama/Llama-3.2-3B-Instruct huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -65,7 +65,7 @@ lemonade -i meta-llama/Llama-3.2-3B-Instruct huggingface-load --device cpu --dty
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i meta-llama/Llama-3.2-3B-Instruct huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i meta-llama/Llama-3.2-3B-Instruct huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/cpu/Llama_3_2_3B_Instruct.md
+++ b/example/llm/cpu/Llama_3_2_3B_Instruct.md
@@ -120,9 +120,7 @@ for new_text in streamer:
 thread.join()
 ```
 
-## Application Example
 
-See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
 
 # Server Interface (REST API)
 

--- a/example/llm/cpu/Meta_Llama_3_8B.md
+++ b/example/llm/cpu/Meta_Llama_3_8B.md
@@ -1,0 +1,147 @@
+# Hugging Face CPU: meta-llama/Meta-Llama-3-8B (bfloat16)
+
+This guide contains all of the instructions necessary to get started with the model `meta-llama/Meta-Llama-3-8B` on Hugging Face CPU in the bfloat16 data type.
+
+The CPU implementation in this guide is designed to run on most PCs. However, for optimal performance on Ryzen AI 300-series PCs, try the [hybrid execution mode](../hybrid/Meta_Llama_3_8B.md).
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework, as well as the support for Hugging Face `transformers` baselines leveraged in this guide.
+
+# Checkpoint
+
+The Hugging Face CPU implementation of `meta-llama/Meta-Llama-3-8B` uses the ONNX Runtime GenAI Model Builder tool, via `lemonade` to export an ONNX model for use in inference.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm]
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i meta-llama/Meta-Llama-3-8B huggingface-load --device cpu --dtype bfloat16 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i meta-llama/Meta-Llama-3-8B huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i meta-llama/Meta-Llama-3-8B huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "meta-llama/Meta-Llama-3-8B", recipe="hf-cpu"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from transformers import TextIteratorStreamer
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained("meta-llama/Meta-Llama-3-8B", recipe="hf-cpu")
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = TextIteratorStreamer(
+    tokenizer,
+    skip_prompt=True,
+)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/cpu/Meta_Llama_3_8B.md
+++ b/example/llm/cpu/Meta_Llama_3_8B.md
@@ -57,7 +57,7 @@ lemonade -i meta-llama/Meta-Llama-3-8B huggingface-load --device cpu --dtype bfl
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i meta-llama/Meta-Llama-3-8B huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i meta-llama/Meta-Llama-3-8B huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -65,7 +65,7 @@ lemonade -i meta-llama/Meta-Llama-3-8B huggingface-load --device cpu --dtype bfl
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i meta-llama/Meta-Llama-3-8B huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i meta-llama/Meta-Llama-3-8B huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/cpu/Meta_Llama_3_8B.md
+++ b/example/llm/cpu/Meta_Llama_3_8B.md
@@ -120,9 +120,7 @@ for new_text in streamer:
 thread.join()
 ```
 
-## Application Example
 
-See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
 
 # Server Interface (REST API)
 

--- a/example/llm/cpu/Mistral_7B_Instruct_v0_3.md
+++ b/example/llm/cpu/Mistral_7B_Instruct_v0_3.md
@@ -57,7 +57,7 @@ lemonade -i mistralai/Mistral-7B-Instruct-v0.3 huggingface-load --device cpu --d
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i mistralai/Mistral-7B-Instruct-v0.3 huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i mistralai/Mistral-7B-Instruct-v0.3 huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -65,7 +65,7 @@ lemonade -i mistralai/Mistral-7B-Instruct-v0.3 huggingface-load --device cpu --d
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i mistralai/Mistral-7B-Instruct-v0.3 huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i mistralai/Mistral-7B-Instruct-v0.3 huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/cpu/Mistral_7B_Instruct_v0_3.md
+++ b/example/llm/cpu/Mistral_7B_Instruct_v0_3.md
@@ -1,0 +1,147 @@
+# Hugging Face CPU: mistralai/Mistral-7B-Instruct-v0.3 (bfloat16)
+
+This guide contains all of the instructions necessary to get started with the model `mistralai/Mistral-7B-Instruct-v0.3` on Hugging Face CPU in the bfloat16 data type.
+
+The CPU implementation in this guide is designed to run on most PCs. However, for optimal performance on Ryzen AI 300-series PCs, try the [hybrid execution mode](../hybrid/Mistral_7B_Instruct_v0_3.md).
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework, as well as the support for Hugging Face `transformers` baselines leveraged in this guide.
+
+# Checkpoint
+
+The Hugging Face CPU implementation of `mistralai/Mistral-7B-Instruct-v0.3` uses the ONNX Runtime GenAI Model Builder tool, via `lemonade` to export an ONNX model for use in inference.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm]
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i mistralai/Mistral-7B-Instruct-v0.3 huggingface-load --device cpu --dtype bfloat16 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i mistralai/Mistral-7B-Instruct-v0.3 huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i mistralai/Mistral-7B-Instruct-v0.3 huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "mistralai/Mistral-7B-Instruct-v0.3", recipe="hf-cpu"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from transformers import TextIteratorStreamer
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained("mistralai/Mistral-7B-Instruct-v0.3", recipe="hf-cpu")
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = TextIteratorStreamer(
+    tokenizer,
+    skip_prompt=True,
+)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/cpu/Mistral_7B_Instruct_v0_3.md
+++ b/example/llm/cpu/Mistral_7B_Instruct_v0_3.md
@@ -120,9 +120,7 @@ for new_text in streamer:
 thread.join()
 ```
 
-## Application Example
 
-See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
 
 # Server Interface (REST API)
 

--- a/example/llm/cpu/Phi_3_5_mini_instruct.md
+++ b/example/llm/cpu/Phi_3_5_mini_instruct.md
@@ -57,7 +57,7 @@ lemonade -i microsoft/Phi-3.5-mini-instruct huggingface-load --device cpu --dtyp
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i microsoft/Phi-3.5-mini-instruct huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i microsoft/Phi-3.5-mini-instruct huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -65,7 +65,7 @@ lemonade -i microsoft/Phi-3.5-mini-instruct huggingface-load --device cpu --dtyp
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i microsoft/Phi-3.5-mini-instruct huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i microsoft/Phi-3.5-mini-instruct huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/cpu/Phi_3_5_mini_instruct.md
+++ b/example/llm/cpu/Phi_3_5_mini_instruct.md
@@ -1,0 +1,147 @@
+# Hugging Face CPU: microsoft/Phi-3.5-mini-instruct (bfloat16)
+
+This guide contains all of the instructions necessary to get started with the model `microsoft/Phi-3.5-mini-instruct` on Hugging Face CPU in the bfloat16 data type.
+
+The CPU implementation in this guide is designed to run on most PCs. However, for optimal performance on Ryzen AI 300-series PCs, try the [hybrid execution mode](../hybrid/Phi_3_5_mini_instruct.md).
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework, as well as the support for Hugging Face `transformers` baselines leveraged in this guide.
+
+# Checkpoint
+
+The Hugging Face CPU implementation of `microsoft/Phi-3.5-mini-instruct` uses the ONNX Runtime GenAI Model Builder tool, via `lemonade` to export an ONNX model for use in inference.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm]
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i microsoft/Phi-3.5-mini-instruct huggingface-load --device cpu --dtype bfloat16 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i microsoft/Phi-3.5-mini-instruct huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i microsoft/Phi-3.5-mini-instruct huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "microsoft/Phi-3.5-mini-instruct", recipe="hf-cpu"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from transformers import TextIteratorStreamer
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained("microsoft/Phi-3.5-mini-instruct", recipe="hf-cpu")
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = TextIteratorStreamer(
+    tokenizer,
+    skip_prompt=True,
+)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/cpu/Phi_3_5_mini_instruct.md
+++ b/example/llm/cpu/Phi_3_5_mini_instruct.md
@@ -120,9 +120,7 @@ for new_text in streamer:
 thread.join()
 ```
 
-## Application Example
 
-See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
 
 # Server Interface (REST API)
 

--- a/example/llm/cpu/Phi_3_mini_4k_instruct.md
+++ b/example/llm/cpu/Phi_3_mini_4k_instruct.md
@@ -1,0 +1,147 @@
+# Hugging Face CPU: microsoft/Phi-3-mini-4k-instruct (bfloat16)
+
+This guide contains all of the instructions necessary to get started with the model `microsoft/Phi-3-mini-4k-instruct` on Hugging Face CPU in the bfloat16 data type.
+
+The CPU implementation in this guide is designed to run on most PCs. However, for optimal performance on Ryzen AI 300-series PCs, try the [hybrid execution mode](../hybrid/Phi_3_mini_4k_instruct.md).
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework, as well as the support for Hugging Face `transformers` baselines leveraged in this guide.
+
+# Checkpoint
+
+The Hugging Face CPU implementation of `microsoft/Phi-3-mini-4k-instruct` uses the ONNX Runtime GenAI Model Builder tool, via `lemonade` to export an ONNX model for use in inference.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm]
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i microsoft/Phi-3-mini-4k-instruct huggingface-load --device cpu --dtype bfloat16 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i microsoft/Phi-3-mini-4k-instruct huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i microsoft/Phi-3-mini-4k-instruct huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "microsoft/Phi-3-mini-4k-instruct", recipe="hf-cpu"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from transformers import TextIteratorStreamer
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained("microsoft/Phi-3-mini-4k-instruct", recipe="hf-cpu")
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = TextIteratorStreamer(
+    tokenizer,
+    skip_prompt=True,
+)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/cpu/Phi_3_mini_4k_instruct.md
+++ b/example/llm/cpu/Phi_3_mini_4k_instruct.md
@@ -57,7 +57,7 @@ lemonade -i microsoft/Phi-3-mini-4k-instruct huggingface-load --device cpu --dty
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i microsoft/Phi-3-mini-4k-instruct huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i microsoft/Phi-3-mini-4k-instruct huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -65,7 +65,7 @@ lemonade -i microsoft/Phi-3-mini-4k-instruct huggingface-load --device cpu --dty
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i microsoft/Phi-3-mini-4k-instruct huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i microsoft/Phi-3-mini-4k-instruct huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/cpu/Phi_3_mini_4k_instruct.md
+++ b/example/llm/cpu/Phi_3_mini_4k_instruct.md
@@ -120,9 +120,7 @@ for new_text in streamer:
 thread.join()
 ```
 
-## Application Example
 
-See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
 
 # Server Interface (REST API)
 

--- a/example/llm/cpu/Qwen1_5_7B_Chat.md
+++ b/example/llm/cpu/Qwen1_5_7B_Chat.md
@@ -57,7 +57,7 @@ lemonade -i Qwen/Qwen1.5-7B-Chat huggingface-load --device cpu --dtype bfloat16 
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i Qwen/Qwen1.5-7B-Chat huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i Qwen/Qwen1.5-7B-Chat huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -65,7 +65,7 @@ lemonade -i Qwen/Qwen1.5-7B-Chat huggingface-load --device cpu --dtype bfloat16 
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i Qwen/Qwen1.5-7B-Chat huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i Qwen/Qwen1.5-7B-Chat huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/cpu/Qwen1_5_7B_Chat.md
+++ b/example/llm/cpu/Qwen1_5_7B_Chat.md
@@ -1,0 +1,147 @@
+# Hugging Face CPU: Qwen/Qwen1.5-7B-Chat (bfloat16)
+
+This guide contains all of the instructions necessary to get started with the model `Qwen/Qwen1.5-7B-Chat` on Hugging Face CPU in the bfloat16 data type.
+
+The CPU implementation in this guide is designed to run on most PCs. However, for optimal performance on Ryzen AI 300-series PCs, try the [hybrid execution mode](../hybrid/Qwen1_5_7B_Chat.md).
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework, as well as the support for Hugging Face `transformers` baselines leveraged in this guide.
+
+# Checkpoint
+
+The Hugging Face CPU implementation of `Qwen/Qwen1.5-7B-Chat` uses the ONNX Runtime GenAI Model Builder tool, via `lemonade` to export an ONNX model for use in inference.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm]
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i Qwen/Qwen1.5-7B-Chat huggingface-load --device cpu --dtype bfloat16 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i Qwen/Qwen1.5-7B-Chat huggingface-load --device cpu --dtype bfloat16 huggingface-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i Qwen/Qwen1.5-7B-Chat huggingface-load --device cpu --dtype bfloat16 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "Qwen/Qwen1.5-7B-Chat", recipe="hf-cpu"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from transformers import TextIteratorStreamer
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained("Qwen/Qwen1.5-7B-Chat", recipe="hf-cpu")
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = TextIteratorStreamer(
+    tokenizer,
+    skip_prompt=True,
+)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/cpu/Qwen1_5_7B_Chat.md
+++ b/example/llm/cpu/Qwen1_5_7B_Chat.md
@@ -120,9 +120,7 @@ for new_text in streamer:
 thread.join()
 ```
 
-## Application Example
 
-See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
 
 # Server Interface (REST API)
 

--- a/example/llm/hybrid/Llama_2_7b_chat_hf.md
+++ b/example/llm/hybrid/Llama_2_7b_chat_hf.md
@@ -73,7 +73,7 @@ lemonade -i amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load 
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -81,7 +81,7 @@ lemonade -i amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load 
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/hybrid/Llama_2_7b_chat_hf.md
+++ b/example/llm/hybrid/Llama_2_7b_chat_hf.md
@@ -1,0 +1,151 @@
+# Ryzen AI Hybrid: meta-llama/Llama-2-7b-chat-hf (int4)
+
+This guide contains all of the instructions necessary to get started with the model `meta-llama/Llama-2-7b-chat-hf` on Ryzen AI Hybrid in the int4 data type.
+
+Hybrid execution mode optimally partitions the model such that different operations are scheduled on NPU vs. iGPU. This minimizes time-to-first-token (TTFT) in the prefill-phase and maximizes token generation (tokens per second, TPS) in the decode phase.
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework.
+
+# Checkpoint
+
+The Ryzen AI Hybrid implementation of `meta-llama/Llama-2-7b-chat-hf` uses the [`amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid) checkpoint on Hugging Face. This checkpoint has been quantized for int4 with AMD Quark using the recipe provided on the model card.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm-oga-hybrid]
+    ```
+
+4. Install support for Ryzen AI Hybrid LLMs.
+    ```bash
+    lemonade-install --ryzenai hybrid
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from lemonade.api import from_pretrained
+from lemonade.tools.ort_genai.oga import OrtGenaiStreamer
+
+model, tokenizer = from_pretrained(
+    "amd/Llama-2-7b-chat-hf-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = OrtGenaiStreamer(tokenizer)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/hybrid/Llama_2_7b_chat_hf.md
+++ b/example/llm/hybrid/Llama_2_7b_chat_hf.md
@@ -18,7 +18,17 @@ To get started with the `lemonade` SDK in a Python environment, follow these ins
 
 You only need to do this once per computer:
 
-1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. Make sure your system has the Ryzen AI 1.3 driver installed:
+    - Download the [NPU driver installation package](https://account.amd.com/en/forms/downloads/ryzen-ai-software-platform-xef.html?filename=NPU_RAI1.3.zip).
+
+    - Install the NPU drivers by following these steps:
+
+        - Extract the downloaded `NPU_RAI1.3.zip` zip file.
+        - Open a terminal in administrator mode and execute the `.
+pu_sw_installer.exe` exe file.
+
+    - Ensure that NPU MCDM driver (Version:32.0.203.237 or 32.0.203.240) is correctly installed by opening `Device Manager` -> `Neural processors` -> `NPU Compute Accelerator Device`.
+
 1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
 1. Launch a terminal and call `conda init`
 

--- a/example/llm/hybrid/Llama_2_7b_hf.md
+++ b/example/llm/hybrid/Llama_2_7b_hf.md
@@ -18,7 +18,17 @@ To get started with the `lemonade` SDK in a Python environment, follow these ins
 
 You only need to do this once per computer:
 
-1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. Make sure your system has the Ryzen AI 1.3 driver installed:
+    - Download the [NPU driver installation package](https://account.amd.com/en/forms/downloads/ryzen-ai-software-platform-xef.html?filename=NPU_RAI1.3.zip).
+
+    - Install the NPU drivers by following these steps:
+
+        - Extract the downloaded `NPU_RAI1.3.zip` zip file.
+        - Open a terminal in administrator mode and execute the `.
+pu_sw_installer.exe` exe file.
+
+    - Ensure that NPU MCDM driver (Version:32.0.203.237 or 32.0.203.240) is correctly installed by opening `Device Manager` -> `Neural processors` -> `NPU Compute Accelerator Device`.
+
 1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
 1. Launch a terminal and call `conda init`
 

--- a/example/llm/hybrid/Llama_2_7b_hf.md
+++ b/example/llm/hybrid/Llama_2_7b_hf.md
@@ -73,7 +73,7 @@ lemonade -i amd/Llama-2-7b-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --dev
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i amd/Llama-2-7b-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i amd/Llama-2-7b-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -81,7 +81,7 @@ lemonade -i amd/Llama-2-7b-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --dev
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i amd/Llama-2-7b-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i amd/Llama-2-7b-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/hybrid/Llama_2_7b_hf.md
+++ b/example/llm/hybrid/Llama_2_7b_hf.md
@@ -1,0 +1,151 @@
+# Ryzen AI Hybrid: meta-llama/Llama-2-7b-hf (int4)
+
+This guide contains all of the instructions necessary to get started with the model `meta-llama/Llama-2-7b-hf` on Ryzen AI Hybrid in the int4 data type.
+
+Hybrid execution mode optimally partitions the model such that different operations are scheduled on NPU vs. iGPU. This minimizes time-to-first-token (TTFT) in the prefill-phase and maximizes token generation (tokens per second, TPS) in the decode phase.
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework.
+
+# Checkpoint
+
+The Ryzen AI Hybrid implementation of `meta-llama/Llama-2-7b-hf` uses the [`amd/Llama-2-7b-hf-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Llama-2-7b-hf-awq-g128-int4-asym-fp16-onnx-hybrid) checkpoint on Hugging Face. This checkpoint has been quantized for int4 with AMD Quark using the recipe provided on the model card.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm-oga-hybrid]
+    ```
+
+4. Install support for Ryzen AI Hybrid LLMs.
+    ```bash
+    lemonade-install --ryzenai hybrid
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i amd/Llama-2-7b-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i amd/Llama-2-7b-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i amd/Llama-2-7b-hf-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "amd/Llama-2-7b-hf-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from lemonade.api import from_pretrained
+from lemonade.tools.ort_genai.oga import OrtGenaiStreamer
+
+model, tokenizer = from_pretrained(
+    "amd/Llama-2-7b-hf-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = OrtGenaiStreamer(tokenizer)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/hybrid/Llama_3_1_8B.md
+++ b/example/llm/hybrid/Llama_3_1_8B.md
@@ -18,7 +18,17 @@ To get started with the `lemonade` SDK in a Python environment, follow these ins
 
 You only need to do this once per computer:
 
-1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. Make sure your system has the Ryzen AI 1.3 driver installed:
+    - Download the [NPU driver installation package](https://account.amd.com/en/forms/downloads/ryzen-ai-software-platform-xef.html?filename=NPU_RAI1.3.zip).
+
+    - Install the NPU drivers by following these steps:
+
+        - Extract the downloaded `NPU_RAI1.3.zip` zip file.
+        - Open a terminal in administrator mode and execute the `.
+pu_sw_installer.exe` exe file.
+
+    - Ensure that NPU MCDM driver (Version:32.0.203.237 or 32.0.203.240) is correctly installed by opening `Device Manager` -> `Neural processors` -> `NPU Compute Accelerator Device`.
+
 1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
 1. Launch a terminal and call `conda init`
 

--- a/example/llm/hybrid/Llama_3_1_8B.md
+++ b/example/llm/hybrid/Llama_3_1_8B.md
@@ -73,7 +73,7 @@ lemonade -i amd/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --devi
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i amd/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i amd/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -81,7 +81,7 @@ lemonade -i amd/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --devi
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i amd/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i amd/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/hybrid/Llama_3_1_8B.md
+++ b/example/llm/hybrid/Llama_3_1_8B.md
@@ -1,0 +1,151 @@
+# Ryzen AI Hybrid: meta-llama/Llama-3.1-8B (int4)
+
+This guide contains all of the instructions necessary to get started with the model `meta-llama/Llama-3.1-8B` on Ryzen AI Hybrid in the int4 data type.
+
+Hybrid execution mode optimally partitions the model such that different operations are scheduled on NPU vs. iGPU. This minimizes time-to-first-token (TTFT) in the prefill-phase and maximizes token generation (tokens per second, TPS) in the decode phase.
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework.
+
+# Checkpoint
+
+The Ryzen AI Hybrid implementation of `meta-llama/Llama-3.1-8B` uses the [`amd/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-hybrid) checkpoint on Hugging Face. This checkpoint has been quantized for int4 with AMD Quark using the recipe provided on the model card.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm-oga-hybrid]
+    ```
+
+4. Install support for Ryzen AI Hybrid LLMs.
+    ```bash
+    lemonade-install --ryzenai hybrid
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i amd/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i amd/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i amd/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "amd/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from lemonade.api import from_pretrained
+from lemonade.tools.ort_genai.oga import OrtGenaiStreamer
+
+model, tokenizer = from_pretrained(
+    "amd/Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = OrtGenaiStreamer(tokenizer)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/hybrid/Llama_3_2_1B_Instruct.md
+++ b/example/llm/hybrid/Llama_3_2_1B_Instruct.md
@@ -18,7 +18,17 @@ To get started with the `lemonade` SDK in a Python environment, follow these ins
 
 You only need to do this once per computer:
 
-1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. Make sure your system has the Ryzen AI 1.3 driver installed:
+    - Download the [NPU driver installation package](https://account.amd.com/en/forms/downloads/ryzen-ai-software-platform-xef.html?filename=NPU_RAI1.3.zip).
+
+    - Install the NPU drivers by following these steps:
+
+        - Extract the downloaded `NPU_RAI1.3.zip` zip file.
+        - Open a terminal in administrator mode and execute the `.
+pu_sw_installer.exe` exe file.
+
+    - Ensure that NPU MCDM driver (Version:32.0.203.237 or 32.0.203.240) is correctly installed by opening `Device Manager` -> `Neural processors` -> `NPU Compute Accelerator Device`.
+
 1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
 1. Launch a terminal and call `conda init`
 

--- a/example/llm/hybrid/Llama_3_2_1B_Instruct.md
+++ b/example/llm/hybrid/Llama_3_2_1B_Instruct.md
@@ -1,0 +1,151 @@
+# Ryzen AI Hybrid: meta-llama/Llama-3.2-1B-Instruct (int4)
+
+This guide contains all of the instructions necessary to get started with the model `meta-llama/Llama-3.2-1B-Instruct` on Ryzen AI Hybrid in the int4 data type.
+
+Hybrid execution mode optimally partitions the model such that different operations are scheduled on NPU vs. iGPU. This minimizes time-to-first-token (TTFT) in the prefill-phase and maximizes token generation (tokens per second, TPS) in the decode phase.
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework.
+
+# Checkpoint
+
+The Ryzen AI Hybrid implementation of `meta-llama/Llama-3.2-1B-Instruct` uses the [`amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid) checkpoint on Hugging Face. This checkpoint has been quantized for int4 with AMD Quark using the recipe provided on the model card.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm-oga-hybrid]
+    ```
+
+4. Install support for Ryzen AI Hybrid LLMs.
+    ```bash
+    lemonade-install --ryzenai hybrid
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from lemonade.api import from_pretrained
+from lemonade.tools.ort_genai.oga import OrtGenaiStreamer
+
+model, tokenizer = from_pretrained(
+    "amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = OrtGenaiStreamer(tokenizer)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/hybrid/Llama_3_2_1B_Instruct.md
+++ b/example/llm/hybrid/Llama_3_2_1B_Instruct.md
@@ -73,7 +73,7 @@ lemonade -i amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-lo
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -81,7 +81,7 @@ lemonade -i amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-lo
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/hybrid/Llama_3_2_3B_Instruct.md
+++ b/example/llm/hybrid/Llama_3_2_3B_Instruct.md
@@ -18,7 +18,17 @@ To get started with the `lemonade` SDK in a Python environment, follow these ins
 
 You only need to do this once per computer:
 
-1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. Make sure your system has the Ryzen AI 1.3 driver installed:
+    - Download the [NPU driver installation package](https://account.amd.com/en/forms/downloads/ryzen-ai-software-platform-xef.html?filename=NPU_RAI1.3.zip).
+
+    - Install the NPU drivers by following these steps:
+
+        - Extract the downloaded `NPU_RAI1.3.zip` zip file.
+        - Open a terminal in administrator mode and execute the `.
+pu_sw_installer.exe` exe file.
+
+    - Ensure that NPU MCDM driver (Version:32.0.203.237 or 32.0.203.240) is correctly installed by opening `Device Manager` -> `Neural processors` -> `NPU Compute Accelerator Device`.
+
 1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
 1. Launch a terminal and call `conda init`
 

--- a/example/llm/hybrid/Llama_3_2_3B_Instruct.md
+++ b/example/llm/hybrid/Llama_3_2_3B_Instruct.md
@@ -1,0 +1,151 @@
+# Ryzen AI Hybrid: meta-llama/Llama-3.2-3B-Instruct (int4)
+
+This guide contains all of the instructions necessary to get started with the model `meta-llama/Llama-3.2-3B-Instruct` on Ryzen AI Hybrid in the int4 data type.
+
+Hybrid execution mode optimally partitions the model such that different operations are scheduled on NPU vs. iGPU. This minimizes time-to-first-token (TTFT) in the prefill-phase and maximizes token generation (tokens per second, TPS) in the decode phase.
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework.
+
+# Checkpoint
+
+The Ryzen AI Hybrid implementation of `meta-llama/Llama-3.2-3B-Instruct` uses the [`amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid) checkpoint on Hugging Face. This checkpoint has been quantized for int4 with AMD Quark using the recipe provided on the model card.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm-oga-hybrid]
+    ```
+
+4. Install support for Ryzen AI Hybrid LLMs.
+    ```bash
+    lemonade-install --ryzenai hybrid
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from lemonade.api import from_pretrained
+from lemonade.tools.ort_genai.oga import OrtGenaiStreamer
+
+model, tokenizer = from_pretrained(
+    "amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = OrtGenaiStreamer(tokenizer)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/hybrid/Llama_3_2_3B_Instruct.md
+++ b/example/llm/hybrid/Llama_3_2_3B_Instruct.md
@@ -73,7 +73,7 @@ lemonade -i amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-lo
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -81,7 +81,7 @@ lemonade -i amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-lo
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/hybrid/Meta_Llama_3_8B.md
+++ b/example/llm/hybrid/Meta_Llama_3_8B.md
@@ -73,7 +73,7 @@ lemonade -i amd/Llama-3-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i amd/Llama-3-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i amd/Llama-3-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -81,7 +81,7 @@ lemonade -i amd/Llama-3-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i amd/Llama-3-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i amd/Llama-3-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/hybrid/Meta_Llama_3_8B.md
+++ b/example/llm/hybrid/Meta_Llama_3_8B.md
@@ -1,0 +1,151 @@
+# Ryzen AI Hybrid: meta-llama/Meta-Llama-3-8B (int4)
+
+This guide contains all of the instructions necessary to get started with the model `meta-llama/Meta-Llama-3-8B` on Ryzen AI Hybrid in the int4 data type.
+
+Hybrid execution mode optimally partitions the model such that different operations are scheduled on NPU vs. iGPU. This minimizes time-to-first-token (TTFT) in the prefill-phase and maximizes token generation (tokens per second, TPS) in the decode phase.
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework.
+
+# Checkpoint
+
+The Ryzen AI Hybrid implementation of `meta-llama/Meta-Llama-3-8B` uses the [`amd/Llama-3-8B-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Llama-3-8B-awq-g128-int4-asym-fp16-onnx-hybrid) checkpoint on Hugging Face. This checkpoint has been quantized for int4 with AMD Quark using the recipe provided on the model card.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm-oga-hybrid]
+    ```
+
+4. Install support for Ryzen AI Hybrid LLMs.
+    ```bash
+    lemonade-install --ryzenai hybrid
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i amd/Llama-3-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i amd/Llama-3-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i amd/Llama-3-8B-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "amd/Llama-3-8B-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from lemonade.api import from_pretrained
+from lemonade.tools.ort_genai.oga import OrtGenaiStreamer
+
+model, tokenizer = from_pretrained(
+    "amd/Llama-3-8B-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = OrtGenaiStreamer(tokenizer)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/hybrid/Meta_Llama_3_8B.md
+++ b/example/llm/hybrid/Meta_Llama_3_8B.md
@@ -18,7 +18,17 @@ To get started with the `lemonade` SDK in a Python environment, follow these ins
 
 You only need to do this once per computer:
 
-1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. Make sure your system has the Ryzen AI 1.3 driver installed:
+    - Download the [NPU driver installation package](https://account.amd.com/en/forms/downloads/ryzen-ai-software-platform-xef.html?filename=NPU_RAI1.3.zip).
+
+    - Install the NPU drivers by following these steps:
+
+        - Extract the downloaded `NPU_RAI1.3.zip` zip file.
+        - Open a terminal in administrator mode and execute the `.
+pu_sw_installer.exe` exe file.
+
+    - Ensure that NPU MCDM driver (Version:32.0.203.237 or 32.0.203.240) is correctly installed by opening `Device Manager` -> `Neural processors` -> `NPU Compute Accelerator Device`.
+
 1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
 1. Launch a terminal and call `conda init`
 

--- a/example/llm/hybrid/Mistral_7B_Instruct_v0_3.md
+++ b/example/llm/hybrid/Mistral_7B_Instruct_v0_3.md
@@ -1,0 +1,151 @@
+# Ryzen AI Hybrid: mistralai/Mistral-7B-Instruct-v0.3 (int4)
+
+This guide contains all of the instructions necessary to get started with the model `mistralai/Mistral-7B-Instruct-v0.3` on Ryzen AI Hybrid in the int4 data type.
+
+Hybrid execution mode optimally partitions the model such that different operations are scheduled on NPU vs. iGPU. This minimizes time-to-first-token (TTFT) in the prefill-phase and maximizes token generation (tokens per second, TPS) in the decode phase.
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework.
+
+# Checkpoint
+
+The Ryzen AI Hybrid implementation of `mistralai/Mistral-7B-Instruct-v0.3` uses the [`amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid) checkpoint on Hugging Face. This checkpoint has been quantized for int4 with AMD Quark using the recipe provided on the model card.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm-oga-hybrid]
+    ```
+
+4. Install support for Ryzen AI Hybrid LLMs.
+    ```bash
+    lemonade-install --ryzenai hybrid
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from lemonade.api import from_pretrained
+from lemonade.tools.ort_genai.oga import OrtGenaiStreamer
+
+model, tokenizer = from_pretrained(
+    "amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = OrtGenaiStreamer(tokenizer)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/hybrid/Mistral_7B_Instruct_v0_3.md
+++ b/example/llm/hybrid/Mistral_7B_Instruct_v0_3.md
@@ -18,7 +18,17 @@ To get started with the `lemonade` SDK in a Python environment, follow these ins
 
 You only need to do this once per computer:
 
-1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. Make sure your system has the Ryzen AI 1.3 driver installed:
+    - Download the [NPU driver installation package](https://account.amd.com/en/forms/downloads/ryzen-ai-software-platform-xef.html?filename=NPU_RAI1.3.zip).
+
+    - Install the NPU drivers by following these steps:
+
+        - Extract the downloaded `NPU_RAI1.3.zip` zip file.
+        - Open a terminal in administrator mode and execute the `.
+pu_sw_installer.exe` exe file.
+
+    - Ensure that NPU MCDM driver (Version:32.0.203.237 or 32.0.203.240) is correctly installed by opening `Device Manager` -> `Neural processors` -> `NPU Compute Accelerator Device`.
+
 1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
 1. Launch a terminal and call `conda init`
 

--- a/example/llm/hybrid/Mistral_7B_Instruct_v0_3.md
+++ b/example/llm/hybrid/Mistral_7B_Instruct_v0_3.md
@@ -73,7 +73,7 @@ lemonade -i amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid oga
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -81,7 +81,7 @@ lemonade -i amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid oga
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/hybrid/Phi_3_5_mini_instruct.md
+++ b/example/llm/hybrid/Phi_3_5_mini_instruct.md
@@ -18,7 +18,17 @@ To get started with the `lemonade` SDK in a Python environment, follow these ins
 
 You only need to do this once per computer:
 
-1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. Make sure your system has the Ryzen AI 1.3 driver installed:
+    - Download the [NPU driver installation package](https://account.amd.com/en/forms/downloads/ryzen-ai-software-platform-xef.html?filename=NPU_RAI1.3.zip).
+
+    - Install the NPU drivers by following these steps:
+
+        - Extract the downloaded `NPU_RAI1.3.zip` zip file.
+        - Open a terminal in administrator mode and execute the `.
+pu_sw_installer.exe` exe file.
+
+    - Ensure that NPU MCDM driver (Version:32.0.203.237 or 32.0.203.240) is correctly installed by opening `Device Manager` -> `Neural processors` -> `NPU Compute Accelerator Device`.
+
 1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
 1. Launch a terminal and call `conda init`
 

--- a/example/llm/hybrid/Phi_3_5_mini_instruct.md
+++ b/example/llm/hybrid/Phi_3_5_mini_instruct.md
@@ -1,0 +1,151 @@
+# Ryzen AI Hybrid: microsoft/Phi-3.5-mini-instruct (int4)
+
+This guide contains all of the instructions necessary to get started with the model `microsoft/Phi-3.5-mini-instruct` on Ryzen AI Hybrid in the int4 data type.
+
+Hybrid execution mode optimally partitions the model such that different operations are scheduled on NPU vs. iGPU. This minimizes time-to-first-token (TTFT) in the prefill-phase and maximizes token generation (tokens per second, TPS) in the decode phase.
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework.
+
+# Checkpoint
+
+The Ryzen AI Hybrid implementation of `microsoft/Phi-3.5-mini-instruct` uses the [`amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid) checkpoint on Hugging Face. This checkpoint has been quantized for int4 with AMD Quark using the recipe provided on the model card.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm-oga-hybrid]
+    ```
+
+4. Install support for Ryzen AI Hybrid LLMs.
+    ```bash
+    lemonade-install --ryzenai hybrid
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from lemonade.api import from_pretrained
+from lemonade.tools.ort_genai.oga import OrtGenaiStreamer
+
+model, tokenizer = from_pretrained(
+    "amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = OrtGenaiStreamer(tokenizer)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/hybrid/Phi_3_5_mini_instruct.md
+++ b/example/llm/hybrid/Phi_3_5_mini_instruct.md
@@ -73,7 +73,7 @@ lemonade -i amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-lo
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -81,7 +81,7 @@ lemonade -i amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-lo
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/hybrid/Phi_3_mini_4k_instruct.md
+++ b/example/llm/hybrid/Phi_3_mini_4k_instruct.md
@@ -73,7 +73,7 @@ lemonade -i amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-l
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -81,7 +81,7 @@ lemonade -i amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-l
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/hybrid/Phi_3_mini_4k_instruct.md
+++ b/example/llm/hybrid/Phi_3_mini_4k_instruct.md
@@ -18,7 +18,17 @@ To get started with the `lemonade` SDK in a Python environment, follow these ins
 
 You only need to do this once per computer:
 
-1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. Make sure your system has the Ryzen AI 1.3 driver installed:
+    - Download the [NPU driver installation package](https://account.amd.com/en/forms/downloads/ryzen-ai-software-platform-xef.html?filename=NPU_RAI1.3.zip).
+
+    - Install the NPU drivers by following these steps:
+
+        - Extract the downloaded `NPU_RAI1.3.zip` zip file.
+        - Open a terminal in administrator mode and execute the `.
+pu_sw_installer.exe` exe file.
+
+    - Ensure that NPU MCDM driver (Version:32.0.203.237 or 32.0.203.240) is correctly installed by opening `Device Manager` -> `Neural processors` -> `NPU Compute Accelerator Device`.
+
 1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
 1. Launch a terminal and call `conda init`
 

--- a/example/llm/hybrid/Phi_3_mini_4k_instruct.md
+++ b/example/llm/hybrid/Phi_3_mini_4k_instruct.md
@@ -1,0 +1,151 @@
+# Ryzen AI Hybrid: microsoft/Phi-3-mini-4k-instruct (int4)
+
+This guide contains all of the instructions necessary to get started with the model `microsoft/Phi-3-mini-4k-instruct` on Ryzen AI Hybrid in the int4 data type.
+
+Hybrid execution mode optimally partitions the model such that different operations are scheduled on NPU vs. iGPU. This minimizes time-to-first-token (TTFT) in the prefill-phase and maximizes token generation (tokens per second, TPS) in the decode phase.
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework.
+
+# Checkpoint
+
+The Ryzen AI Hybrid implementation of `microsoft/Phi-3-mini-4k-instruct` uses the [`amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid) checkpoint on Hugging Face. This checkpoint has been quantized for int4 with AMD Quark using the recipe provided on the model card.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm-oga-hybrid]
+    ```
+
+4. Install support for Ryzen AI Hybrid LLMs.
+    ```bash
+    lemonade-install --ryzenai hybrid
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from lemonade.api import from_pretrained
+from lemonade.tools.ort_genai.oga import OrtGenaiStreamer
+
+model, tokenizer = from_pretrained(
+    "amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = OrtGenaiStreamer(tokenizer)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.

--- a/example/llm/hybrid/Qwen1_5_7B_Chat.md
+++ b/example/llm/hybrid/Qwen1_5_7B_Chat.md
@@ -18,7 +18,17 @@ To get started with the `lemonade` SDK in a Python environment, follow these ins
 
 You only need to do this once per computer:
 
-1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. Make sure your system has the Ryzen AI 1.3 driver installed:
+    - Download the [NPU driver installation package](https://account.amd.com/en/forms/downloads/ryzen-ai-software-platform-xef.html?filename=NPU_RAI1.3.zip).
+
+    - Install the NPU drivers by following these steps:
+
+        - Extract the downloaded `NPU_RAI1.3.zip` zip file.
+        - Open a terminal in administrator mode and execute the `.
+pu_sw_installer.exe` exe file.
+
+    - Ensure that NPU MCDM driver (Version:32.0.203.237 or 32.0.203.240) is correctly installed by opening `Device Manager` -> `Neural processors` -> `NPU Compute Accelerator Device`.
+
 1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
 1. Launch a terminal and call `conda init`
 

--- a/example/llm/hybrid/Qwen1_5_7B_Chat.md
+++ b/example/llm/hybrid/Qwen1_5_7B_Chat.md
@@ -73,7 +73,7 @@ lemonade -i amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --d
 To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
 
 ```bash
-lemonade -i amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+lemonade -i amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 5 --iterations 10 --prompt 1024 --output-tokens 64
 ```
 
 ## Task Performance
@@ -81,7 +81,7 @@ lemonade -i amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --d
 To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
 
 ```bash
-lemonade -i amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+lemonade -i amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests management
 ```
 
 # Application Integration

--- a/example/llm/hybrid/Qwen1_5_7B_Chat.md
+++ b/example/llm/hybrid/Qwen1_5_7B_Chat.md
@@ -1,0 +1,151 @@
+# Ryzen AI Hybrid: Qwen/Qwen1.5-7B-Chat (int4)
+
+This guide contains all of the instructions necessary to get started with the model `Qwen/Qwen1.5-7B-Chat` on Ryzen AI Hybrid in the int4 data type.
+
+Hybrid execution mode optimally partitions the model such that different operations are scheduled on NPU vs. iGPU. This minimizes time-to-first-token (TTFT) in the prefill-phase and maximizes token generation (tokens per second, TPS) in the decode phase.
+
+The commands and scripts in this guide leverage the `lemonade` SDK from the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml) project. The `lemonade` SDK provides everything you need to get up and running with LLMs on the OnnxRuntime GenAI (OGA) framework.
+
+# Checkpoint
+
+The Ryzen AI Hybrid implementation of `Qwen/Qwen1.5-7B-Chat` uses the [`amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid) checkpoint on Hugging Face. This checkpoint has been quantized for int4 with AMD Quark using the recipe provided on the model card.
+
+# Setup
+
+To get started with the `lemonade` SDK in a Python environment, follow these instructions.
+
+### System-level pre-requisites
+
+You only need to do this once per computer:
+
+1. Make sure your system has the [Ryzen AI 1.3 driver](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers) installed.
+1. [Download and install miniconda for Windows](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe). 
+1. Launch a terminal and call `conda init`
+
+### Lemonade Installation
+
+To create and set up an environment, run these commands in your terminal:
+
+1. Create environment.
+    ```bash
+    conda create -n ryzenai-llm python=3.10
+    ```
+
+2. Activate environment.
+    ```bash
+    conda activate ryzenai-llm
+    ```
+
+3. Install ONNX TurnkeyML to get access to the LLM tools and APIs.
+    ```bash
+    pip install turnkeyml[llm-oga-hybrid]
+    ```
+
+4. Install support for Ryzen AI Hybrid LLMs.
+    ```bash
+    lemonade-install --ryzenai hybrid
+    ```
+
+# Validation Tools
+
+You can use the following `lemonade` commands to test out your model, in your activated `ryzenai-llm` environment.
+
+## Prompting
+
+To prompt the model and get a response (where `PROMPT` is a prompt of your choosing):
+
+```bash
+lemonade -i amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 llm-prompt --max-new-tokens 64 -p PROMPT
+```
+
+## Responsiveness
+
+To measure the model's time-to-first-token (TTFT) and tokens/second with a sequence length of 1024 and 64 output tokens:
+
+```bash
+lemonade -i amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench --warmup-iterations 10 --iterations 20 --prompt 1024 --output-tokens 64
+```
+
+## Task Performance
+
+To measure the model's accuracy on the [MMLU test](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/mmlu_accuracy.md) `management` subject, run:
+
+```bash
+lemonade -i amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 accuracy-mmlu --tests astronomy philosophy management
+```
+
+# Application Integration
+
+## Blocking
+
+To integrate blocking generation into your application (i.e., the entire response is delivered at once), replace your existing LLM invocation with this code:
+
+```python
+from lemonade.api import from_pretrained
+
+model, tokenizer = from_pretrained(
+    "amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+response = model.generate(input_ids, max_new_tokens=30)
+
+print(tokenizer.decode(response[0]))
+```
+
+## Streaming
+
+To integrate streaming generation into your application (i.e., each token of the response is streamed back to the main thread as soon as it becomes available), replace your existing LLM invocation with this code:
+
+```python
+from threading import Thread
+from lemonade.api import from_pretrained
+from lemonade.tools.ort_genai.oga import OrtGenaiStreamer
+
+model, tokenizer = from_pretrained(
+    "amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid", recipe="oga-hybrid"
+)
+input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
+
+streamer = OrtGenaiStreamer(tokenizer)
+generation_kwargs = {
+    "input_ids": input_ids,
+    "streamer": streamer,
+    "max_new_tokens": 30,
+}
+
+thread = Thread(target=model.generate, kwargs=generation_kwargs)
+thread.start()
+
+# Generate the response using streaming
+for new_text in streamer:
+    print(new_text)
+
+thread.join()
+```
+
+## Application Example
+
+See the [Chat Demo](https://github.com/onnx/turnkeyml/blob/main/examples/lemonade/demos/chat/chat_hybrid.py) for an example application that demonstrates streaming, multi-threading, and response interruption.
+
+# Server Interface (REST API)
+
+To launch a server process from your Python environment, run the command:
+
+```bash
+lemonade serve
+```
+
+Once launched, the APIs for accessing the server are the same, regardless of which LLM and device was used to launch the server. Check out the [Sever Interface documentation](https://ryzenai.docs.amd.com/en/latest/llm/server_interface.html) to understand how to interact with the server process.
+
+# Next Steps
+
+This guide provided instructions for testing and deploying an LLM on a target device using the `lemonade` SDK's tools and APIs. 
+
+- Visit the table of [Supported LLMs table](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#supported-llms) in the documentation to learn how to do this for any of the supported combinations of LLM and device.
+- Visit the [overall LLM documentation](https://ryzenai.docs.amd.com/en/latest/llm/overview.html#) to learn about other deployment options, such as native C++ libraries.
+- Visit the [lemonade SDK repository](https://github.com/onnx/turnkeyml/blob/main/docs/lemonade/getting_started.md) to learn about more tools and features.
+
+# Copyright
+
+Copyright(C) 2025 Advanced Micro Devices, Inc. All rights reserved.


### PR DESCRIPTION
This PR adds a set of LLM guides under `example/llm`.

Each guide has a comprehensive step-by-step guide for getting one LLM up and running on target hardware and then deploy that LLM instantiation into an application.

There are 20 guides in total:
- All 10 of the OGA-compatible hybrid models from AMD's Hugging Face collection.
- How to get the same 10 models running on CPU as a reference.

These guides are auto-generated and auto-validated by the `lemonade` project.
- Validation runs every command in the guide on STX hardware to ensure that they run correctly, then compares the CPU and Hybrid versions of the guides to make sure the performance and accuracy metrics are good.

Requires https://github.com/amd/ryzen-ai-documentation/pull/343 to merge so that the documentation links will work.

cc @vgodsoe 