### PR TITLE
fix: harden whisper demo setup paths

### DIFF
--- a/Demos/ASR/Whisper/run_whisper.py
+++ b/Demos/ASR/Whisper/run_whisper.py
@@ -216,6 +216,13 @@ def load_provider_options(config, model_name, device):
 
 
 def mic_stream(model, duration=0, silence_threshold=0.01, silence_duration=5.0):
+    try:
+        import sounddevice as sd
+    except ImportError:
+        print("\n⚠️ sounddevice is required for microphone input.")
+        print("   Install it with `pip install sounddevice` or use a .wav file instead.")
+        return
+
     q_audio = queue.Queue()
     stop_flag = threading.Event()
 
@@ -354,11 +361,7 @@ def main():
         return
 
     if args.input.lower() == 'mic':
-        import sounddevice as sd
-        try:
-            mic_stream(model, args.duration)
-        except sd.PortAudioError as e:
-            print("Fix your device or try using a .wav file instead of mic. Exiting")
+        mic_stream(model, args.duration)
         return
     else:
         waveform, sr = torchaudio.load(args.input)

--- a/Demos/ASR/Whisper/run_whisper.py
+++ b/Demos/ASR/Whisper/run_whisper.py
@@ -14,6 +14,12 @@ from huggingface_hub import snapshot_download
 
 SAMPLE_RATE = 16000
 CHUNK_SIZE = 1600  # 0.1 sec chunks
+SUPPORTED_WHISPER_MODEL_TYPES = (
+    "whisper-base",
+    "whisper-small",
+    "whisper-medium",
+    "whisper-large-v3-turbo",
+)
 
 
 class WhisperONNX:
@@ -281,9 +287,10 @@ def download_whisper_onnx(model_type: str):
     Returns paths to encoder and decoder model files.
     """
     hf_model_map = {
+        "whisper-base": "amd/whisper-base-onnx-npu",
         "whisper-small": "amd/whisper-small-onnx-npu",
         "whisper-medium": "amd/whisper-medium-onnx-npu",
-        "whisper-large-v3-turbo": "amd/whisper-large-turbo-onnx-npu"
+        "whisper-large-v3-turbo": "amd/whisper-large-turbo-onnx-npu",
     }
 
     repo_id = hf_model_map.get(model_type)
@@ -310,10 +317,12 @@ def main():
     parser.add_argument("--input", help="WAV file path or 'mic'")
     parser.add_argument("--encoder", help="Path to Whisper encoder ONNX model (optional, auto-download if not provided)")
     parser.add_argument("--decoder", help="Path to Whisper decoder ONNX model (optional, auto-download if not provided)")
-    parser.add_argument("--model-type", required=True, default="whisper-base",
-                        choices=["whisper-tiny", "whisper-base", "whisper-small",
-                                 "whisper-medium", "whisper-large-v3-turbo"],
-                        help="Whisper model name")
+    parser.add_argument(
+        "--model-type",
+        default="whisper-base",
+        choices=SUPPORTED_WHISPER_MODEL_TYPES,
+        help="Whisper model name",
+    )
     parser.add_argument("--eval-dir", help="Dataset directory with wavs/ and transcripts.txt")
     parser.add_argument("--results-dir", default="results", help="Directory to store evaluation results")
     parser.add_argument("--config-file", default="./config/model_config.json", help="Path to Model provider configs")


### PR DESCRIPTION
## What
- localize the `sounddevice` import to `mic_stream()`
- remove the `main()`-scoped microphone import dependency
- align the Whisper CLI model contract with the auto-download helper
- make `whisper-base` auto-downloadable and stop advertising unsupported `whisper-tiny`

## Why
`mic_stream()` uses `sd.InputStream`, `sd.sleep`, and `sd.PortAudioError`, but `sounddevice as sd` was only imported later inside `main()`. That can break the microphone path before the symbol is in scope.

The same demo also advertised `whisper-base` as the default and `whisper-tiny` as a valid choice while the auto-download helper only knew about `small`, `medium`, and `large-v3-turbo`. That made the documented/default setup path inconsistent before inference even started.

Closes #349.

## Validation
- `python -m py_compile Demos/ASR/Whisper/run_whisper.py`
- mocked `mic_stream()` smoke with a fake `sounddevice` module, no real microphone access, and no NPU/model load
- AST contract check confirming the supported CLI model list matches the auto-download model map