### PR TITLE
Fix yolov8m example py3 round issue on PHX/HPT

### DIFF
--- a/CNN-examples/object_detection/yolov8m/run_inference.py
+++ b/CNN-examples/object_detection/yolov8m/run_inference.py
@@ -121,7 +121,8 @@ def main(args):
                 'cache_key': 'modelcachekey',
                 'enable_cache_file_io_in_mem':'0',
                 'target': 'X1',
-                'xclbin': get_xclbin(npu_device)
+                'xclbin': get_xclbin(npu_device),
+                'xlnx_enable_py3_round': 0 # PHX/HPT devices are not compatible with the default py3 rounding mode.
             }]
         elif npu_device == 'STX' or 'KRK':
             provider_options = [{


### PR DESCRIPTION
New Ryzen AI 1.7 default py3 rounding mode is not compatible with PHX/HPT devices, which gives an error.
Setting 'xlnx_enable_py3_round' option to 0, as explained in [installation instructions](https://ryzenai.docs.amd.com/en/latest/inst.html), allows to fix the issue.