### PR TITLE
Fix quark quantization PHX/HPT NPU options

### DIFF
--- a/CNN-examples/quark_quantization/README.md
+++ b/CNN-examples/quark_quantization/README.md
@@ -197,8 +197,8 @@ cache_dir = Path(__file__).parent.resolve()
 print(cache_dir)
 provider_options = [{
                 'config_file': 'vaip_config.json',
-                'cacheDir': str(cache_dir),
-                'cacheKey': 'modelcachekey'
+                'cache_dir': str(cache_dir),
+                'cache_key': 'modelcachekey'
             }]
 
 session = ort.InferenceSession(quant_model.SerializeToString(), providers=provider,
@@ -234,4 +234,3 @@ Advancted Quantization Tools
 ----------------------------
 
 While the default quantization configurations work well for many popular models, more sophisticated models might experience a decline in accuracy due to errors introduced during the quantization process. To address this, Quark APIs offer advanced tools to help recover lost accuracy. Some of these tools are highlighted in the [Advanced Quantization Tools](../docs/advanced_quant_readme.md) tutorial.
-

--- a/CNN-examples/quark_quantization/quark_quantize.py
+++ b/CNN-examples/quark_quantization/quark_quantize.py
@@ -106,16 +106,17 @@ def main(args):
         provider = ['VitisAIExecutionProvider']
         cache_dir = Path(__file__).parent.resolve()
         provider_options = [{
-                    'cacheDir': str(cache_dir),
-                    'cacheKey': 'modelcachekey',
-                    'enable_cache_file_io_in_mem':'0'
-                }]
+            'cache_dir': str(cache_dir),
+            'cache_key': 'modelcachekey',
+            'enable_cache_file_io_in_mem': '0'
+        }]
         # Create session options
         session_options = ort.SessionOptions()
         session_options.log_severity_level = 1  # 0=Verbose, 1=Info, 2=Warning, 3=Error, 4=Fatal
         # For PHX/HPT, xclbin is required
         if npu_device == 'PHX/HPT':
             provider_options[0]['target'] = 'X1'
+            provider_options[0]['xlnx_enable_py3_round'] = 0
             provider_options[0]['xclbin'] = get_xclbin(npu_device)
         session = ort.InferenceSession(quant_model.SerializeToString(),
                                        sess_options=session_options,


### PR DESCRIPTION
Summary\n- Align quark_quantization benchmark VitisAI EP cache options with the working int8 ResNet predict path by using cache_dir/cache_key.\n- Set xlnx_enable_py3_round=0 for PHX/HPT alongside the required target and xclbin options.\n- Update the README NPU provider-options snippet so users copy the same option style.\n\nWhy\nIssue #376 reports that CNN-examples/quark_quantization/quark_quantize.py falls back to CPU on PHX/HPT while the same quantized model runs on the NPU through CNN-examples/getting_started_resnet/int8/predict.py. The benchmark path was using different provider option keys and missing the PHX/HPT rounding option used by the working path.\n\nTesting\n- python3 -m py_compile CNN-examples/quark_quantization/quark_quantize.py CNN-examples/quark_quantization/utils.py\n- git diff --check\n\nNot run locally: PHX/HPT NPU benchmark validation, because this machine does not have Ryzen AI hardware/XRT.\n\nFixes #376